### PR TITLE
Added final working analysis scripts as of 1st July 2024

### DIFF
--- a/AnalyseBehaviour_K1.m
+++ b/AnalyseBehaviour_K1.m
@@ -1,0 +1,267 @@
+function [output, ratingsTable] = AnalyseBehaviour_K1(data, group,toplot)
+% Inputs:
+ %toplot = 1; when data should be plotted, else 0
+
+% groups: [1 = pd off,2 = pd on,3 = Old_HC_controls]
+% Output:
+% output   = structure
+%     .StayData     = stay probabilities
+%     .StaySim      = stay probabilities simulated data
+%     .Rating       = ratings
+%     .Attention    = attention effect on stay behaviour
+%     .Location     = location effect on stay behaviour
+%     .MB           = model-based control
+%     .MF           = model-free control
+%     .MBsim        = model-based control simulated data
+%     .MFsim        = model-free control simulated data
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+experiment = getGroupLabel(group);
+N = data.Nch;
+
+
+nsub        = length(data);
+nRepeat     = length(data(1).A);
+rr          = nan(nsub,4);
+rr1          = nan(nsub,4);
+rr0          = nan(nsub,4);
+rrs         = nan(nsub,4,nRepeat);
+missed      = nan(nsub,1);
+AvRating    = nan(nsub,4);
+ll          = nan(nsub,4);
+ratingsTable = table();
+
+for sub = 1:nsub
+
+    %% Analyse Real Data
+    a       = data(sub).A;
+    missed(sub,1) = sum(isnan(sum(a,2)));
+    idx     = 1:192;
+    a       = a(idx,:);
+    s       = data(sub).S(idx,:);
+    r       = data(sub).R(idx);
+    nl      = data(sub).nl_orientation(idx);
+    trans   = data(sub).trans(idx);
+    stay1    = a(2:end,1)==a(1:end-1,1);
+    rr(sub,1) = nanmean(stay1 (trans(1:end-1)==1 & r(1:end-1)==1)); % CR
+    rr(sub,2) = nanmean(stay1 (trans(1:end-1)==0 & r(1:end-1)==1)); % RR
+    rr(sub,3) = nanmean(stay1 (trans(1:end-1)==1 & r(1:end-1)==0)); % CU
+    rr(sub,4) = nanmean(stay1 (trans(1:end-1)==0 & r(1:end-1)==0)); % RU
+    
+
+
+    %% Analyse Rating and Attention effect
+    irrelshape      = data(sub).shapeIdx(idx,:);
+    ratingIdx       = data(sub).ratingIdx(idx);
+    c1              = data(sub).A(idx,1);
+    win             = data(sub).R(idx);
+    stay            = c1(2:end,1)==c1(1:end-1,1);
+    correct         = data(sub).correct(idx);
+    u1              = 3 - c1;
+    ratings         = data(sub).Rating(idx);
+
+    chosenShapes    = nan(N,1);
+    unchosenShapes  = nan(N,1);
+
+    for t = 1:N
+        if ~isnan(c1(t))
+            chosenShapes(t) = irrelshape(t,c1(t));
+            unchosenShapes(t) = irrelshape(t,u1(t));
+        end
+    end
+
+    woncs   = nan(N,1);    % last time won chosen shape
+    wonus   = nan(N,1);    % last time won unchosen shape 
+    commonC = nan(N,1);    % transition chosen shape
+    commonU = nan(N,1);    % transition unchosen shape
+    last_chosen_distance    = nan(N,1);    % distance between probes chosen
+    last_unchosen_distance  = nan(N,1);    % distance between probes unchosen
+    correctChoice           = nan(N,1);    % choice that leads to best outcome
+
+    for i = 1:length(c1)
+        % find the last time chosen stimulus was probed
+        lastcs = find(chosenShapes(1:i) == ratingIdx(i), 1, 'last'); 
+        % find last time the unchosen shape was choice 1 
+        lastus = find(unchosenShapes(1:i) == ratingIdx(i), 1, 'last');
+
+        % for chosen shape
+        if ~isempty(lastcs)
+            woncs(i)        = win(lastcs);
+            commonC(i)      = trans(lastcs);
+            correctChoice(i) = correct(lastcs);
+            last_chosen_distance(i) = i - lastcs;
+        end
+
+        % for unchosen shape
+        if ~isempty(lastus)
+            wonus(i)        = win(lastus);
+            commonU(i)      = trans(lastus);
+            last_unchosen_distance (i) = i - lastus;
+        end
+
+    end
+
+    normratings = data(sub).zRating;
+    
+    % Compute average rating for each transition and reward
+    AvRating(sub,1)= nanmean(normratings(commonC == 1 & woncs == 1 ));
+    AvRating(sub,2)= nanmean(normratings(commonC == 0 & woncs == 1 ));
+    AvRating(sub,3)= nanmean(normratings(commonC == 1 & woncs == 0 ));
+    AvRating(sub,4)= nanmean(normratings(commonC == 0 & woncs == 0 ));
+ 
+    %% Analyse location effects
+    location        = data(sub).LRchoice(idx);
+    locationStay    = location(2:end,1) == location(1:end-1,1);
+    
+    ll(sub,1) = mean(locationStay (trans(1:end-1)==1 & r(1:end-1)==1)); % CR
+    ll(sub,2) = mean(locationStay (trans(1:end-1)==0 & r(1:end-1)==1)); % RR
+    ll(sub,3) = mean(locationStay (trans(1:end-1)==1 & r(1:end-1)==0)); % CU
+    ll(sub,4) = mean(locationStay (trans(1:end-1)==0 & r(1:end-1)==0)); % RU
+
+    id = repelem(sub, 192,1);
+    srt = table(id, normratings, woncs, commonC, wonus, commonU, last_chosen_distance, last_unchosen_distance);
+    ratingsTable = [ratingsTable; srt];
+end
+
+% Compute the model-based and model-free values
+mb = (rr(:,1) - rr(:,2)) - (rr(:,3) - rr(:,4));
+mf = (rr(:,1) + rr(:,2)) - (rr(:,3) + rr(:,4));
+mb_rating = (AvRating(:,1) - AvRating(:,2)) - (AvRating(:,3) - AvRating(:,4));
+mf_rating = (AvRating(:,1) + AvRating(:,2)) - (AvRating(:,3) + AvRating(:,4));
+
+
+stayData = rr;
+stayLocation = ll;
+
+%% Plot the data
+if toplot   % plot the data
+%% Stay behaviour real data
+    f = figure('Name', 'Daw Plots', 'PaperOrientation','landscape', 'Position', [200 400 600 400]);
+    sgtitle([getGroupLabel(group) ' Behaviour | Ratings | Location | MB and MF Indices'])
+    axes1 = subplot(1,4,1);
+    hold(axes1,'on');
+
+    y = [mean(stayData(:,1:2)); mean(stayData(:,3:4))];
+    stdev = [std(stayData(:,1:2)); std(stayData(:,3:4))]/sqrt(nsub);
+
+    ngroups = size(y, 1);
+    nbars = size(y, 2);
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+
+    ha1 = bar(y, 'Parent',axes1,'BarWidth',1, 'LineWidth', 2);
+    set(ha1(1),'DisplayName','Common','FaceColor','b', 'FaceAlpha', 1);
+    set(ha1(2),'DisplayName','Rare','FaceColor','r', 'FaceAlpha', 1);
+    for i = 1:nbars
+        x = (1:ngroups) - groupwidth/2 + (2*i-1) * groupwidth / (2*nbars);
+        errorbar(x, y(:,i), stdev(:,i),'k', 'LineStyle', 'none', 'LineWidth', 1);
+    end
+    box(axes1,'on');
+    set(axes1,'XTick',[1 2],'XTickLabel',{'Rewarded','Unrewarded'}, 'LineWidth', 1);
+    set(axes1,'Ylim',[0.5 1], 'YTick',[0.5 0.75 1]);
+    %legend({'Common' 'Rare'})
+    ylabel('Stay Probability');
+    title([getGroupLabel(group)]);
+ 
+%% Rating data
+    axes2 = subplot(1,4,2);
+    hold(axes2,'on');
+
+    y = [mean(AvRating(:,1:2)); mean(AvRating(:,3:4))];
+    stdev = [std(AvRating(:,1:2)); std(AvRating(:,3:4))]/sqrt(nsub);
+
+    ngroups = size(y, 1);
+    nbars = size(y, 2);
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+
+    ha1 = bar(y, 'Parent',axes2,'BarWidth',1, 'LineWidth', 2);
+    set(ha1(1),'DisplayName','Common','FaceColor','b', 'FaceAlpha', 1);
+    set(ha1(2),'DisplayName','Rare','FaceColor','r', 'FaceAlpha', 1);
+    for i = 1:nbars
+        x = (1:ngroups) - groupwidth/2 + (2*i-1) * groupwidth / (2*nbars);
+        errorbar(x, y(:,i), stdev(:,i),'k', 'LineStyle', 'none', 'LineWidth', 1);
+    end
+    box(axes2,'on');
+    set(axes2,'XTick',[1 2],'XTickLabel',{'Rewarded','Unrewarded'}, 'LineWidth', 1);
+    %legend({'Common' 'Rare'})
+    set(axes2,'Ylim',[-0.15 0.15]);
+    ylabel('Rating');
+    title([getGroupLabel(group)]);
+
+    
+%% Stay behaviour Location
+    axes3 = subplot(1,4,3);
+    hold(axes3,'on');
+
+    y = [mean(stayLocation(:,1:2)); mean(stayLocation(:,3:4))];
+    stdev = [std(stayLocation(:,1:2)); std(stayLocation(:,3:4))]/sqrt(nsub);
+
+    ngroups = size(y, 1);
+    nbars = size(y, 2);
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+
+    ha1 = bar(y, 'Parent',axes3,'BarWidth',1, 'LineWidth', 2);
+    set(ha1(1),'DisplayName','Common','FaceColor','b', 'FaceAlpha', 1);
+    set(ha1(2),'DisplayName','Rare','FaceColor','r', 'FaceAlpha', 1);
+    for i = 1:nbars
+        x = (1:ngroups) - groupwidth/2 + (2*i-1) * groupwidth / (2*nbars);
+        errorbar(x, y(:,i), stdev(:,i),'k', 'LineStyle', 'none', 'LineWidth', 1);
+    end
+    box(axes3,'on');
+    set(axes3,'XTick',[1 2],'XTickLabel',{'Rewarded','Unrewarded'}, 'LineWidth', 1);
+    set(axes3,'Ylim',[0 1], 'YTick',[0 0.5 1]);
+    ylabel('Stay Probability');
+    title('Location Effect');
+    %legend({'Common' 'Rare'})
+
+%% MB and MF plot
+    axes4 = subplot(1,4,4);
+    hold(axes4,'on');
+
+    y = [mean(mb); mean(mf)];
+    stdev = [std(mb); std(mf)]/sqrt(nsub);
+
+    ngroups = length(y);
+    nbars = 1;  % Only one set of bars
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+    
+    ha1 = bar(axes4, y, 'BarWidth', 0.5, 'LineWidth', 2);
+    
+    % Set properties for each bar
+    set(ha1, 'FaceColor', 'flat');
+    colors = [0 0 1; 1 0 0];  % Blue for MB, Red for MF
+    for k = 1:ngroups
+        ha1.CData(k, :) = colors(k, :);
+    end
+    
+    % Add error bars
+    x = ha1.XEndPoints;
+    errorbar(x, y, stdev, 'k', 'LineStyle', 'none', 'LineWidth', 1);
+    
+    box(axes4,'on');
+    set(axes4, 'XTick', 1:ngroups, 'XTickLabel', {'MB', 'MF'}, 'LineWidth', 1);
+    set(axes4, 'YLim', [min(y - stdev) - 0.1, max(y + stdev) + 0.1]);
+    ylabel('Index');
+    title('Model-Based vs Model-Free');
+
+
+    % Adjust figure size
+    set(f,'units','centimeter','position',[1,5,50,7])
+    
+    exportgraphics(gcf,['OG Graphs + MBMFi ', getGroupLabel(group), '.pdf'])
+
+end
+
+
+
+%% Store relevant data
+output.stayData     = stayData;
+output.Rating       = AvRating;
+output.Location     = stayLocation;
+output.MB           = mb;
+output.MF           = mf;
+output.MBrating     = mb_rating;
+output.MFrating     = mf_rating;
+output.missed       = missed;
+
+end

--- a/AnalyseBehaviour_nl.m
+++ b/AnalyseBehaviour_nl.m
@@ -1,0 +1,243 @@
+function [output, ratingsTable] = AnalyseBehaviour_nl(data, group,toplot)
+% Inputs:
+ %toplot = 1; when data should be plotted, else 0
+
+% groups: [1 = pd off,2 = pd on,3 = Old_HC_controls]
+% Output:
+% output   = structure
+%     .StayData     = stay probabilities
+%     .StaySim      = stay probabilities simulated data
+%     .Rating       = ratings
+%     .Attention    = attention effect on stay behaviour
+%     .Location     = location effect on stay behaviour
+%     .MB           = model-based control
+%     .MF           = model-free control
+%     .MBsim        = model-based control simulated data
+%     .MFsim        = model-free control simulated data
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+experiment = getGroupLabel(group);
+N = data.Nch;
+
+
+nsub        = length(data);
+nRepeat     = length(data(1).A);
+rr          = nan(nsub,4);
+rr1          = nan(nsub,4);
+rr0          = nan(nsub,4);
+rrs         = nan(nsub,4,nRepeat);
+missed      = nan(nsub,1);
+AvRating    = nan(nsub,4);
+ll          = nan(nsub,4);
+ratingsTable = table();
+
+for sub = 1:nsub
+
+    %% Analyse Real Data
+    a       = data(sub).A;
+    missed(sub,1) = sum(isnan(sum(a,2)));
+    idx     = 1:192;
+    a       = a(idx,:);
+    s       = data(sub).S(idx,:);
+    r       = data(sub).R(idx);
+    nl      = data(sub).nl_orientation(idx);
+    trans   = data(sub).trans(idx);
+    stay1    = a(2:end,1)==a(1:end-1,1);
+    rr(sub,1) = nanmean(stay1 (trans(1:end-1)==1 & r(1:end-1)==1)); % CR
+    rr(sub,2) = nanmean(stay1 (trans(1:end-1)==0 & r(1:end-1)==1)); % RR
+    rr(sub,3) = nanmean(stay1 (trans(1:end-1)==1 & r(1:end-1)==0)); % CU
+    rr(sub,4) = nanmean(stay1 (trans(1:end-1)==0 & r(1:end-1)==0)); % RU
+    
+
+
+    %% Analyse Rating and Attention effect
+    irrelshape      = data(sub).shapeIdx(idx,:);
+    ratingIdx       = data(sub).ratingIdx(idx);
+    c1              = data(sub).A(idx,1);
+    win             = data(sub).R(idx);
+    stay            = c1(2:end,1)==c1(1:end-1,1);
+    correct         = data(sub).correct(idx);
+    u1              = 3 - c1;
+    ratings         = data(sub).Rating(idx);
+
+    chosenShapes    = nan(N,1);
+    unchosenShapes  = nan(N,1);
+
+    for t = 1:N
+        if ~isnan(c1(t))
+            chosenShapes(t) = irrelshape(t,c1(t));
+            unchosenShapes(t) = irrelshape(t,u1(t));
+        end
+    end
+
+    woncs   = nan(N,1);    % last time won chosen shape
+    wonus   = nan(N,1);    % last time won unchosen shape 
+    commonC = nan(N,1);    % transition chosen shape
+    commonU = nan(N,1);    % transition unchosen shape
+    last_chosen_distance    = nan(N,1);    % distance between probes chosen
+    last_unchosen_distance  = nan(N,1);    % distance between probes unchosen
+    correctChoice           = nan(N,1);    % choice that leads to best outcome
+
+    for i = 1:length(c1)
+        % find the last time chosen stimulus was probed
+        lastcs = find(chosenShapes(1:i) == ratingIdx(i), 1, 'last'); 
+        % find last time the unchosen shape was choice 1 
+        lastus = find(unchosenShapes(1:i) == ratingIdx(i), 1, 'last');
+
+        % for chosen shape
+        if ~isempty(lastcs)
+            woncs(i)        = win(lastcs);
+            commonC(i)      = trans(lastcs);
+            correctChoice(i) = correct(lastcs);
+            last_chosen_distance(i) = i - lastcs;
+        end
+
+        % for unchosen shape
+        if ~isempty(lastus)
+            wonus(i)        = win(lastus);
+            commonU(i)      = trans(lastus);
+            last_unchosen_distance (i) = i - lastus;
+        end
+
+    end
+
+    normratings = data(sub).zRating;
+    
+    % Compute average rating for each transition and reward
+    AvRating(sub,1)= nanmean(normratings(commonC == 1 & woncs == 1 ));
+    AvRating(sub,2)= nanmean(normratings(commonC == 0 & woncs == 1 ));
+    AvRating(sub,3)= nanmean(normratings(commonC == 1 & woncs == 0 ));
+    AvRating(sub,4)= nanmean(normratings(commonC == 0 & woncs == 0 ));
+
+    rr1(sub,1) = nanmean(normratings(commonC == 1 & woncs == 1 & nl(1) == 1)); % CR
+    rr1(sub,2) = nanmean(normratings(commonC == 0 & woncs == 1 & nl(1) == 1)); % RR
+    rr1(sub,3) = nanmean(normratings(commonC == 1 & woncs == 0 & nl(1) == 1)); % CU
+    rr1(sub,4) = nanmean(normratings(commonC == 0 & woncs == 0 & nl(1) == 1)); % RU
+
+    rr0(sub,1) = nanmean(normratings(commonC == 1 & woncs == 1 & nl(1) == 0)); % CR
+    rr0(sub,2) = nanmean(normratings(commonC == 0 & woncs == 1 & nl(1) == 0)); % RR
+    rr0(sub,3) = nanmean(normratings(commonC == 1 & woncs == 0 & nl(1) == 0)); % CU
+    rr0(sub,4) = nanmean(normratings(commonC == 0 & woncs == 0 & nl(1) == 0)); % RU   
+ 
+    %% Analyse location effects
+    location        = data(sub).LRchoice(idx);
+    locationStay    = location(2:end,1) == location(1:end-1,1);
+    
+    ll(sub,1) = mean(locationStay (trans(1:end-1)==1 & r(1:end-1)==1)); % CR
+    ll(sub,2) = mean(locationStay (trans(1:end-1)==0 & r(1:end-1)==1)); % RR
+    ll(sub,3) = mean(locationStay (trans(1:end-1)==1 & r(1:end-1)==0)); % CU
+    ll(sub,4) = mean(locationStay (trans(1:end-1)==0 & r(1:end-1)==0)); % RU
+
+    id = repelem(sub, 192,1);
+    srt = table(id, normratings, woncs, commonC, wonus, commonU, last_chosen_distance, last_unchosen_distance);
+    ratingsTable = [ratingsTable; srt];
+end
+
+% Compute the model-based and model-free values
+mb = (rr(:,1) - rr(:,2)) - (rr(:,3) - rr(:,4));
+mf = (rr(:,1) + rr(:,2)) - (rr(:,3) + rr(:,4));
+mb_rating = (AvRating(:,1) - AvRating(:,2)) - (AvRating(:,3) - AvRating(:,4));
+mf_rating = (AvRating(:,1) + AvRating(:,2)) - (AvRating(:,3) + AvRating(:,4));
+
+
+stayData = rr1;
+stayLocation = rr0;
+
+%% Plot the data
+if toplot   % plot the data
+%% Stay behaviour real data
+    f = figure('Name', 'Daw Plots', 'PaperOrientation','landscape', 'Position', [200 400 600 400]);
+    sgtitle([getGroupLabel(group) ' nl = 1 | Ratings | nl = 0'])
+    axes1 = subplot(1,3,1);
+    hold(axes1,'on');
+
+    y = [nanmean(stayData(:,1:2)); nanmean(stayData(:,3:4))];
+    stdev = [nanstd(stayData(:,1:2)); nanstd(stayData(:,3:4))]/sqrt(nsub);
+
+    ngroups = size(y, 1);
+    nbars = size(y, 2);
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+
+    ha1 = bar(y, 'Parent',axes1,'BarWidth',1, 'LineWidth', 2);
+    set(ha1(1),'DisplayName','Common','FaceColor','b', 'FaceAlpha', 1);
+    set(ha1(2),'DisplayName','Rare','FaceColor','r', 'FaceAlpha', 1);
+    for i = 1:nbars
+        x = (1:ngroups) - groupwidth/2 + (2*i-1) * groupwidth / (2*nbars);
+        errorbar(x, y(:,i), stdev(:,i),'k', 'LineStyle', 'none', 'LineWidth', 1);
+    end
+    box(axes1,'on');
+    set(axes1,'XTick',[1 2],'XTickLabel',{'Rewarded','Unrewarded'}, 'LineWidth', 1);
+    set(axes1,'Ylim',[-0.2 0.3]);
+    %legend({'Common' 'Rare'})
+    ylabel('rating');
+    title([getGroupLabel(group)]);
+ 
+%% Rating data
+    axes2 = subplot(1,3,2);
+    hold(axes2,'on');
+
+    y = [mean(AvRating(:,1:2)); mean(AvRating(:,3:4))];
+    stdev = [std(AvRating(:,1:2)); std(AvRating(:,3:4))]/sqrt(nsub);
+
+    ngroups = size(y, 1);
+    nbars = size(y, 2);
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+
+    ha1 = bar(y, 'Parent',axes2,'BarWidth',1, 'LineWidth', 2);
+    set(ha1(1),'DisplayName','Common','FaceColor','b', 'FaceAlpha', 1);
+    set(ha1(2),'DisplayName','Rare','FaceColor','r', 'FaceAlpha', 1);
+    for i = 1:nbars
+        x = (1:ngroups) - groupwidth/2 + (2*i-1) * groupwidth / (2*nbars);
+        errorbar(x, y(:,i), stdev(:,i),'k', 'LineStyle', 'none', 'LineWidth', 1);
+    end
+    box(axes2,'on');
+    set(axes2,'XTick',[1 2],'XTickLabel',{'Rewarded','Unrewarded'}, 'LineWidth', 1);
+    %legend({'Common' 'Rare'})
+    set(axes2,'Ylim',[-0.15 0.15]);
+    ylabel('Rating');
+    title([getGroupLabel(group)]);
+
+    
+%% Stay behaviour Location
+    axes3 = subplot(1,3,3);
+    hold(axes3,'on');
+
+    y = [nanmean(stayLocation(:,1:2)); nanmean(stayLocation(:,3:4))];
+    stdev = [nanstd(stayLocation(:,1:2)); nanstd(stayLocation(:,3:4))]/sqrt(nsub);
+
+    ngroups = size(y, 1);
+    nbars = size(y, 2);
+    groupwidth = min(0.8, nbars/(nbars + 1.5));
+
+    ha1 = bar(y, 'Parent',axes3,'BarWidth',1, 'LineWidth', 3);
+    set(ha1(1),'DisplayName','Common','FaceColor','b', 'FaceAlpha', 1);
+    set(ha1(2),'DisplayName','Rare','FaceColor','r', 'FaceAlpha', 1);
+    for i = 1:nbars
+        x = (1:ngroups) - groupwidth/2 + (2*i-1) * groupwidth / (2*nbars);
+        errorbar(x, y(:,i), stdev(:,i),'k', 'LineStyle', 'none', 'LineWidth', 1);
+    end
+    box(axes3,'on');
+    set(axes3,'XTick',[1 2],'XTickLabel',{'Rewarded','Unrewarded'}, 'LineWidth', 1);
+    set(axes3,'Ylim',[-0.2 0.3]);
+    ylabel('Stay Probability');
+    title('nl = 0');
+    %legend({'Common' 'Rare'})
+
+    set(f,'units','centimeter','position',[1,5,35,7])
+
+    exportgraphics(gcf,['ratings daw by nl ', getGroupLabel(group), '.pdf'])
+
+end
+
+%% Store relevant data
+output.stayData     = stayData;
+output.Rating       = AvRating;
+output.Location     = stayLocation;
+output.MB           = mb;
+output.MF           = mf;
+output.MBrating     = mb_rating;
+output.MFrating     = mf_rating;
+output.missed       = missed;
+
+end

--- a/FINALfigures.m
+++ b/FINALfigures.m
@@ -1,0 +1,311 @@
+%% Final Figures
+tf = 16; % set the font for all titles
+
+% Figure 2: Behaviour figure ( Behav | Ratings | Location | MBi MFi )
+for group = 1:3
+    data = load(sprintf('groupData_group%d', group));
+    data = data.GroupData;
+    ouput = AnalyseBehaviour_K1(data, group,0);
+end
+
+
+
+%% Extracting Random effect of trial 
+% pd off random effects of trial
+Tpdoff = fitlme(TWpdoff, 'normratings ~ win + trial + (trial|subjectID)')
+[~,~,OFFstats] = randomEffects(Tpdoff);
+Trial_estimates{2} = OFFstats(2:2:end,:);
+
+% pd on random effects of trial
+Tpdon = fitlme(TWpdon, 'normratings ~ win + trial + (trial|subjectID)')
+[~,~,ONstats] = randomEffects(Tpdon);
+Trial_estimates{1} = ONstats(2:2:end,:);
+
+% controls random effect of trial 
+Tcontrols = fitlme(TWcontrols, 'normratings ~ win + trial + (trial|subjectID)')
+[~,~,Cstats] = randomEffects(Tcontrols);
+Trial_estimates{3} = Cstats(2:2:end,:);
+
+column = [];
+for i = 1:3 
+    column = [column; Trial_estimates{i}(:,4)];
+end 
+t = dataset2struct(column); % follow by copy past the structure into a new column 
+tt = struct2table(t);
+
+shortTable.Estimate = tt.Estimate;
+
+
+% Figure 3: RE of Trial and Correlation between AMI Subscores & RE Trail
+
+
+X = shortTable.AMITotal;
+X2 = shortTable.AMIBehaviour;
+X3 = shortTable.AMISocial;
+X4 = shortTable.AMIEmotional;
+Y = shortTable.Estimate;
+Z = shortTable.grp;
+ID = shortTable.i;
+
+% Initialize gramm objects
+g(1,1) = gramm('x', Z, 'y', Y, 'color', Z, 'group', Z); % Bar chart of Estimates with error bars
+g(1,2) = gramm('x', X, 'y', Y, 'color', Z, 'group', Z); % AMI Total plot
+g(1,3) = gramm('x', X2, 'y', Y, 'color', Z, 'group', Z); % AMI Social plot
+g(1,4) = gramm('x', X3, 'y', Y, 'color', Z, 'group', Z); % AMI Social plot
+g(1,5) = gramm('x', X4, 'y', Y, 'color', Z, 'group', Z); % AMI Emotional plot
+
+% Settings for Bar chart (Estimates with error bars)
+g(1,1).geom_jitter('width', 0.4); % Jitter plot with dodging
+g(1,1).stat_summary('type', 'sem', 'geom', {'point', 'black_errorbar'}); % Add error bars
+g(1,1).set_names('x', 'Group', 'y', 'Random Effect of Trial (x10e-3)', 'color', 'Group'); % Set axis labels
+g(1,1).geom_hline('yintercept', 0, 'style', 'k--');
+g(1,1).set_title('Random Effects of Trial', 'FontSize', tf)
+
+% Settings for AMI plot
+g(1,2).geom_point(); 
+g(1,2).geom_hline('yintercept', 0, 'style', 'k--');  % Add a dashed horizontal line at y = 0
+g(1,2).stat_glm('fullrange', true, 'geom', {'line', 'area'}); % Add summary statistics or glms
+g(1,2).set_names('x', 'AMI Score', 'y', '', 'color', 'Group'); % Set axis labels
+g(1,2).set_title('AMI', 'FontSize', tf); % Set plot title
+
+% Settings for Grit plot
+g(1,3).geom_point(); 
+g(1,3).geom_hline('yintercept', 0, 'style', 'k--');  % Add a dashed horizontal line at y = 0
+g(1,3).stat_glm('fullrange', true, 'geom', {'line', 'area'}); % Add summary statistics or glms
+g(1,3).set_names('x', 'AMI Behaviour Score', 'y', '', 'color', 'Group'); % Set axis labels
+g(1,3).set_title('Behaviour', 'FontSize', tf); % Set plot title
+
+% Settings for AMI Social plot
+g(1,4).geom_point(); 
+g(1,4).geom_hline('yintercept', 0, 'style', 'k--');  % Add a dashed horizontal line at y = 0
+g(1,4).stat_glm('fullrange', true, 'geom', {'line', 'area'}); % Add summary statistics or glms
+g(1,4).set_names('x', 'AMI Social Score', 'y', '', 'color', 'Group'); % Set axis labels
+g(1,4).set_title('Social', 'FontSize', tf); % Set plot title
+
+% Settings for AMI Emotional plot
+g(1,5).geom_point(); 
+g(1,5).geom_hline('yintercept', 0, 'style', 'k--');  % Add a dashed horizontal line at y = 0
+g(1,5).stat_glm('fullrange', true, 'geom', {'line', 'area'}); % Add summary statistics or glms
+g(1,5).set_names('x', 'AMI Emotional Score', 'y', '', 'color', 'Group'); % Set axis labels
+g(1,5).set_title('Emotional', 'FontSize', tf); % Set plot title
+for i = 1:5
+    g(1,i).no_legend()
+end
+
+% Overall settings for the combined figure
+set(findall(gcf, '-property', 'FontSize'), 'FontSize', 16); % Adjust font size
+
+% Draw the plots
+f = figure('PaperOrientation','landscape','Position', [100 100 1600 400]);
+g.draw();
+print(gcf, 'figures/random_effects_plot', '-dpdf', '-bestfit');
+
+
+
+
+% Figure 4: Ratings over time | Ratings over time split by high / low AMI (Contols and PD)
+figure('PaperOrientation','landscape','Position', [100 100 1600 400]);
+% Plot of ratings for all three groups
+subplot(1,3,1)
+
+conditionalPlot(TWcontrols.trial, TWcontrols.normratings, [], 'color', [1.00,0.37,0.41])
+hold on
+conditionalPlot(TWpdon.trial, TWpdon.normratings, [], 'color', [0.00,0.66,1.00])
+conditionalPlot(TWpdoff.trial, TWpdoff.normratings, [], 'color', [0.03,0.71,0.29])
+line(get(gca, 'XLim'), [0 0], 'Color', [0.5 0.5 0.5], 'LineStyle', '--', 'LineWidth', 1.5);
+hold off
+legend({'','Controls','','PD on','','PD off'}, 'Fontsize', tf-6); legend('boxoff')
+title('Ratings over trials', 'FontSize', tf); ylabel('Ratings')
+xlabel('Trial', 'FontSize', tf-4)
+ylabel('Ratings', 'FontSize', tf-4)
+ylim([-0.5 0.5])
+
+
+% High and low AMI in control
+%motivated people start off lower, but for every trial motivated people
+%increase ratings by .007
+subplot(1,3,2)
+mdl = fitlme(TWcontrols, 'normratings ~ trial*motivation*nl + (1|subjectID)');
+group = TWcontrols.motivation < median(TWcontrols.motivation);
+conditionalPlot(TWcontrols.trial(group), TWcontrols.normratings(group), [], 'color', [1, 0.6, 0.6])
+hold on
+conditionalPlot(TWcontrols.trial(~group), TWcontrols.normratings(~group), [], 'color', [0.8, 0, 0])
+line(get(gca, 'XLim'), [0 0], 'Color', [0.5 0.5 0.5], 'LineStyle', '--', 'LineWidth', 1.5);
+hold off
+xlabel('Trial', 'FontSize', tf-4)
+ylabel('Ratings', 'FontSize', tf-4); ylim([-0.5, 0.5]);
+legend({ "", 'Low AMI', "",'High AMI'}, 'Fontsize', tf-6); legend('boxoff')
+title('Controls', 'FontSize',tf)
+
+% Effect of high / low AMI in PD
+
+group = TWpd.motivation < median(TWpd.motivation);
+med = TWpd.medication == 1;
+
+mdl = fitlme(TWpd, 'normratings ~ trial*motivation*medication + (1|subjectID)');
+% three way interaction indicates that  apathetic patients when off reduce their ratings, but the drug prevents this
+subplot(1,3,3)
+conditionalPlot(TWpd.trial(group & med), TWpd.normratings(group & med), [], 'color', [0, 0, 0.5]) % dark blue, pd on
+hold on
+conditionalPlot(TWpd.trial(~group & med), TWpd.normratings(~group & med), [], 'color', [0.6, 0.6, 1]) % light blue, pd on
+conditionalPlot(TWpd.trial(group & ~med), TWpd.normratings(group & ~med), [], 'color', [0, 0.5, 0]) % dark green, pd off
+conditionalPlot(TWpd.trial(~group & ~med), TWpd.normratings(~group & ~med), [], 'color', [0.6, 1, 0.6]) % light green, pd off
+line(get(gca, 'XLim'), [0 0], 'Color', [0.5 0.5 0.5], 'LineStyle', '--', 'LineWidth', 1.5);
+hold off
+xlabel('Trial', 'FontSize', tf-4)
+ylabel('Ratings', 'FontSize', tf-4); ylim([-0.5, 0.5])
+legend({"",'ON: Low AMI',  "",'ON: High AMI',"", 'OFF: Low AMI', "",'OFF: High AMI'}, 'Fontsize', tf-6); legend('boxoff');
+title('PD', 'FontSize',tf)
+print(gcf, 'figures/ratings plots', '-dpdf', '-bestfit');
+
+% Figure: Performance 
+clear g;
+
+% Define data 
+GRP = shortTable.grp;
+MF = shortTable.pMF;
+MB = shortTable.pMB;
+AMIT = shortTable.AMITotal;
+AMIB = shortTable.AMIBehaviour;
+AMIS = shortTable.AMISocial;
+AMIE = shortTable.AMIEmotional;
+GritTotal = shortTable.GritTotal;
+SUPPSP = shortTable.SUPPSP;
+HADSTotal = shortTable.HADSTotal;
+pstay = shortTable.pstay;
+pcorrect = shortTable.pcorrect;
+pwin = shortTable.pwin;
+id = shortTable.i;
+
+% MF: Create gramm objects for the first set of plots
+g(1,1) = gramm('x', GRP, 'y', pwin, 'color', GRP, 'group', GRP);
+g(1,2) = gramm('x', GRP, 'y', pstay, 'color', GRP, 'group', GRP);
+g(1,3) = gramm('x', GRP, 'y', pcorrect, 'color', GRP, 'group', GRP);
+
+% Apply methods to each gramm object separately for the first set of plots
+
+for j = 1:3
+    g(1,j).geom_jitter();
+     g(1,j).stat_summary('type','sem', 'geom', 'black_errorbar')
+end
+
+% Set plot labels for each subplot 
+g(1,1).set_names('x', ' ', 'y', 'Performance (% wins)');
+g(1,2).set_names('x', ' ', 'y', 'Performance (% correct)');
+g(1,3).set_names('x', ' ', 'y', 'Stay probability');
+
+% Remove all legends and titles
+g.set_layout_options('legend', false);
+g.set_title('Performance');
+
+% Create a new figure window for the combined plots
+figure('Name', 'Performance plots', 'PaperOrientation', 'landscape', 'Position', [200 400 1600 400]);
+
+% Draw the combined plots
+g.draw();
+set(findall(gcf, '-property', 'FontSize'), 'FontSize', 12);
+
+%% Supplementary figures
+clear g;
+
+% Define data for the first set of plots
+GRP = shortTable.grp;
+ID = shortTable.i;
+a = shortTable.pMF;
+b = shortTable.pMB;
+l = shortTable.AMITotal;
+p = shortTable.AMIBehaviour;
+o = shortTable.AMISocial;
+
+% MF: Create gramm objects for the first set of plots
+g(1,1) = gramm('x', GRP, 'y', a, 'color', GRP, 'subset', ID);
+g(1,2) = gramm('x', GRP, 'y', b, 'color', GRP, 'subset', ID);
+g(1,3) = gramm('x', GRP, 'y', l, 'color', GRP, 'subset', ID);
+g(1,4) = gramm('x', GRP, 'y', p, 'color', GRP, 'subset', ID);
+g(1,5) = gramm('x', GRP, 'y', o, 'color', GRP, 'subset', ID);
+
+% Apply methods to each gramm object separately for the first set of plots
+for i = 1:5
+    g(1,i).geom_jitter();
+    g(1,i).stat_glm('geom', 'line', 'fullrange', 1, 'disp_fit', 0);  % CI and bars
+    g(1,i).geom_abline('intercept', 0, 'slope', 0, 'style', 'k--');
+end
+
+% Set plot labels for each subplot in the first set of plots
+g(1,1).set_names('x', 'AMI Total Score', 'y', 'Model Free Index');
+g(1,2).set_names('x', 'AMI Behaviour Score', 'y', 'Model Free Index');
+g(1,3).set_names('x', 'AMI Social Score', 'y', 'Model Free Index');
+g(1,4).set_names('x', 'AMI Emotional Score', 'y', 'Model Free Index');
+
+g(2,1).set_names('x', 'AMI Total Score', 'y', 'Model Based Index');
+g(2,2).set_names('x', 'AMI Behaviour Score', 'y', 'Model Based Index');
+g(2,3).set_names('x', 'AMI Social Score', 'y', 'Model Based Index');
+g(2,4).set_names('x', 'AMI Emotional Score', 'y', 'Model Based Index');
+
+% Define data for the second set of plots
+GRP = shortTable.grp;
+MF = shortTable.pMF;
+MB = shortTable.pMB;
+GritTotal = shortTable.GritTotal;
+SUPPSP = shortTable.SUPPSP;
+HADSTotal = shortTable.HADSTotal;
+pstay = shortTable.pstay;
+pcorrect = shortTable.pcorrect;
+
+% MF: Create gramm objects for the second set of plots
+g(3,1) = gramm('x', GritTotal, 'y', MF, 'color', GRP);
+g(3,2) = gramm('x', SUPPSP, 'y', MF, 'color', GRP);
+g(3,3) = gramm('x', HADSTotal, 'y', MF, 'color', GRP);
+g(3,4) = gramm('x', pstay, 'y', MF, 'color', GRP);
+g(3,5) = gramm('x', pcorrect, 'y', MF, 'color', GRP);
+
+% MB: Create gramm objects for the second set of plots
+g(4,1) = gramm('x', GritTotal, 'y', MB, 'color', GRP);
+g(4,2) = gramm('x', SUPPSP, 'y', MB, 'color', GRP);
+g(4,3) = gramm('x', HADSTotal, 'y', MB, 'color', GRP);
+g(4,4) = gramm('x', pstay, 'y', MB, 'color', GRP);
+g(4,5) = gramm('x', pcorrect, 'y', MB, 'color', GRP);
+
+% Apply methods to each gramm object separately for the second set of plots
+for i = 3:4
+    for j = 1:5
+        g(i,j).geom_point();
+        g(i,j).stat_glm('geom', 'line', 'fullrange', 1, 'disp_fit', 0);  % CI and bars
+        g(i,j).geom_abline('intercept', 0, 'slope', 0, 'style', 'k--');
+    end
+end
+
+% Set plot labels for each subplot in the second set of plots
+g(3,1).set_names('x', 'Grit Score', 'y', 'Model Free Index');
+g(3,2).set_names('x', 'Impulsivity', 'y', 'Model Free Index');
+g(3,3).set_names('x', 'HADS Score', 'y', 'Model Free Index');
+g(3,4).set_names('x', 'Probability Stay', 'y', 'Model Free Index');
+g(3,5).set_names('x', 'Probability Correct', 'y', 'Model Free Index');
+
+g(4,1).set_names('x', 'Grit Score', 'y', 'Model Based Index');
+g(4,2).set_names('x', 'Impulsivity', 'y', 'Model Based Index');
+g(4,3).set_names('x', 'HADS Score', 'y', 'Model Based Index');
+g(4,4).set_names('x', 'Probability Stay', 'y', 'Model Based Index');
+g(4,5).set_names('x', 'Probability Correct', 'y', 'Model Based Index');
+
+% Set unified point and line options for all plots
+for i = 1:4
+    for j = 1:5
+        g(i,j).set_point_options('base_size', 8);
+        g(i,j).set_line_options('base_size', 2);
+    end
+end
+
+% Remove all legends and titles
+g.set_layout_options('legend', false);
+g.set_title('');
+
+% Create a new figure window for the combined plots
+figure('Name', 'Combined Clinical Regressions', 'PaperOrientation', 'landscape', 'Position', [200 400 1600 1200]);
+
+% Draw the combined plots
+g.draw();
+set(findall(gcf, '-property', 'FontSize'), 'FontSize', 16);
+
+
+

--- a/FullScript.m
+++ b/FullScript.m
@@ -1,0 +1,532 @@
+%% This is the compiled script designed to:
+% 1. extract task and demographic data,
+% 2. analyse behaviour and ratings on the task using PDGraphingTR_K
+% 3. make a results table for linear models & generate tables to assess the
+% significant effects/interactions and model fits
+% 4. optimize learning parameters using fitWrapper and LLmodelRating_K (EM works)
+% 5. generate RPEs based on the modelled s1 colour / s2 shape value
+% 6. look at the best fitting RPE to explain ratings change
+
+%% Set options
+clear
+options.savetables = 0; % do you want to save tables for the group data, ratings, results tables (short and trialwise)
+options.GenerateSurrData = 0; % generate surrogate data?
+options.fitRegression = 0; % do you want to regress the ratings against the generated RPEs?
+options.GenerateCondPlots = 0; %to be added, but do you want to generate RPE vs ratingschange plots? 
+options.optimize = 0; % do you want to fit a RL model to the data using LLmodelRating_K?
+
+filenames= { 
+{
+'PD101_OFF.mat', 'PD102_OFF.mat', 'PD103_OFF.mat', 'PD104_OFF.mat'...
+'PD105_OFF.mat','PD106_OFF.mat','PD107_OFF.mat','PD108_OFF.mat','PD110_OFF.mat'...
+'PD111_OFF.mat', 'PD112_OFF.mat', 'PD113_OFF.mat', 'PD114_OFF.mat'...
+'PD115_OFF.mat','PD116_OFF.mat','PD117_OFF.mat','PD119_OFF.mat','PD120_OFF.mat'...
+}
+{
+'PD101_ON.mat', 'PD102_ON.mat', 'PD103_ON.mat', 'PD104_ON.mat'...
+'PD105_ON.mat','PD106_ON.mat','PD107_ON.mat','PD108_ON.mat','PD110_ON.mat'...
+'PD111_ON.mat', 'PD112_ON.mat', 'PD113_ON.mat', 'PD114_ON.mat'...
+'PD115_ON.mat','PD116_ON.mat','PD117_ON.mat','PD119_ON.mat','PD120_ON.mat'...
+}
+{
+'C101.mat', 'C102.mat', 'C103.mat', 'C104.mat', 'C105.mat', 'C106.mat', 'C107.mat', ...
+'C108.mat', 'C109.mat', 'C110.mat', 'C111.mat', 'C112.mat', 'C113.mat', 'C114.mat',...
+'C115.mat', 'C116.mat', 'C117.mat', 'C118.mat' 'C119.mat'...
+}
+};
+
+% initialize the structures and tables 
+stayprobTable = table; HCstayprobTable = table; HCGroupData = []; shortTable = []; clear subjectData
+groupRPEt = table(); allRPEt = table(); GroupTable = table(); params = [];
+
+PDDemographicData = load("PDDemographicData.mat"); 
+HCDemographicData = load("HCDemographicData.mat"); 
+f = figure('Name', 'Selected subplots', 'PaperOrientation','landscape');
+for group = 1:3
+    GroupData = []; groupRPEt = table(); GroupTable = table(); allratings = table();%initialize structures and figures 
+    for i = 1:length(filenames{group, 1}) % for the number of cells in filenames
+        filename = filenames{group}{i}; %extract the filename corresponding to the current subject & group
+        result = load(filename); %load the datafile
+        subjectData.ID = i; % set subject ID to the current loop number
+        
+        if group < 3
+            dd = PDDemographicData.data(i,:);
+            subjectData.AMI = dd.AMITotal;
+            subjectData.AMIB = dd.AMIBehaviour;
+            subjectData.AMIS = dd.AMISocial;
+            subjectData.AMIE = dd.AMIEmotional;
+            subjectData.HADS = dd.HADSTotal;
+            subjectData.UPDRST = dd.UPDRSTotal;
+            subjectData.Grit = dd.GritTotal; 
+            subjectData.Impulsivity = dd.SUPPSP;
+            subjectData.Age = dd.Age;
+            subjectData.Sex = dd.Sex;
+        elseif group == 3
+            dd = HCDemographicData.data(i,:);
+            subjectData.AMI = dd.AMITotal;
+            subjectData.AMIB = dd.AMIBehaviour;
+            subjectData.AMIS = dd.AMISocial;
+            subjectData.AMIE = dd.AMIEmotional;
+            subjectData.HADS = dd.HADSTotal;
+            subjectData.UPDRST = 0;
+            subjectData.Grit = dd.GritTotal; 
+            subjectData.Impulsivity = dd.SUPPSP;
+            subjectData.Age = dd.Age;
+            subjectData.Sex = dd.Sex;
+        end
+        if group == 1
+            Med = -1; Dis = 1; 
+            if i < 10; subjectData.LearningEffect = 1; % for these participants, this session was the 2nd visit
+            else; subjectData.LearningEffect = -1; % for these participants, this session was the first
+            end
+        elseif group == 2
+            Med = 1; Dis = 1; % set PDon to med = 1, dis = 1 to measure effects of medication
+            if i >= 10 
+                subjectData.LearningEffect = -1; % for these participants, this session was the first
+            else 
+                subjectData.LearningEffect = 1; % for these participants, this session was the 2nd visit
+            end
+        elseif group == 3
+            Med = 0; Dis = 0; %set PDoff to default group = 0 and med = 0
+            subjectData.LearningEffect = -1; % no learning effect, as they only did one session
+            subjectData.ID = i+18; 
+        end
+
+        subjectData.Med = Med;
+        subjectData.Dis = Dis;
+        % Extract variables for the current subject
+        subjectData.group = group;
+        subjectData.ID = i; % set subject ID to the current loop number
+
+        subjectData.A = [result.data.colour_s1, result.data.response_s2]; 
+        %action at s1 (red = 1, blue = 2) and shape at s2 (1-4)
+        subjectData.Ashape = [result.data.response_s1]; % which s1 shape was chosen (1-5)
+        subjectData.R = [result.data.reward]; % did they get a reward
+        subjectData.S = [ones(size(result.data.s2_state)), result.data.s2_state]; 
+        %state at s1 (always 1) and s2 (state 1 = shapes 1/2, state 2 = shapes 3/4)
+        subjectData.shapeIdx = [ floor(result.data.irrels/10), mod(result.data.irrels,10) ]; 
+        % what shapes were presented at stage 1 (red | blue)
+        
+        subjectData.Nch = length(result.data.s3_shape); %number of trials
+        subjectData.ratingIdx = [result.data.s3_shape]; %which shape was presented for rating (1-5)?
+        subjectData.trans = [result.data.isConsistentMapping]; %common trial (0 = no, 1 = yes)
+        subjectData.startTransferChoice = [result.data.t_start_s3]; %time rating shape presented
+        subjectData.endTransferChoice = [result.data.t_response_s3]; %time rating response submitted
+        subjectData.start = [result.data.t_start_s1]; %s1 time of presentation
+        subjectData.finish = [result.data.t_response_s1]; %response time on s1
+        subjectData.correct = [result.data.correct]; % was the s1 choice correct (s2 shape == high value shape)?
+        subjectData.LRchoice = [result.data.location_s1]; % was the chosen s1 colour left or right?
+        subjectData.high_value_shape = [result.data.high_value_shape]; %which shape had the high value
+ 
+        subjectData.RT = subjectData.finish - subjectData.start;
+        subjectData.version = [result.data.ExperimentVersion];
+
+        %make reward probability matrix for s2 shapes based on high value shape (p(r) = 0.8)
+        rewprobValue = 0.2; rewprobArray = zeros(2, 2, 50);
+        for k = 1:subjectData.Nch
+            highValueIndex = subjectData.high_value_shape(k);
+            rewprobArray(:, :, k) = rewprobValue; % Set all values to 0.2
+            if highValueIndex == 1; rewprobArray(1, 1, k) = 0.8;
+            elseif highValueIndex == 2; rewprobArray(1, 2, k) = 0.8;
+            elseif highValueIndex == 3; rewprobArray(2, 1, k) = 0.8;
+            else; rewprobArray(2, 2, k) = 0.8;
+            end
+
+        end
+        subjectData.rewprob = rewprobArray;       
+        subjectData.Performance = sum(subjectData.R)/subjectData.Nch; % measure performance
+        subjectData.ScreenSize = result.data.ParticipantViewportSize;
+
+        subjectData.nl_orientation = result.data.nl_orientation; nl = subjectData.nl_orientation(1); % what orientation was the number line? (1 = vert, 0 = horizontal)
+        
+        % Handle repeated rating coordinates - these were trials on which the participant did not respond 
+        % and were thus given exactly the same coordinate as the previous trial 
+        rating_coord = result.data.rating_Coord;
+        nan_idx = false(size(subjectData.RT));
+        for t = 2:length(rating_coord)
+            if subjectData.RT(t) >= 4000
+                nan_idx(t) = true;
+            end
+        end
+        
+        % Apply NaN indices to all fields of the missed trial
+        subjectData.A(nan_idx, :) = NaN;
+        subjectData.Ashape(nan_idx) = NaN;
+        subjectData.R(nan_idx) = NaN;
+        subjectData.S(nan_idx, :) = NaN;
+        subjectData.shapeIdx(nan_idx, :) = NaN;
+        subjectData.ratingIdx(nan_idx) = NaN;
+        subjectData.trans(nan_idx) = NaN;
+        subjectData.startTransferChoice(nan_idx) = NaN;
+        subjectData.endTransferChoice(nan_idx) = NaN;
+        subjectData.start(nan_idx) = NaN;
+        subjectData.finish(nan_idx) = NaN;
+        subjectData.correct(nan_idx) = NaN;
+        subjectData.LRchoice(nan_idx) = NaN;
+        subjectData.high_value_shape(nan_idx) = NaN;
+        
+        % Initialize the adjusted_rating_Coord array
+        adjusted_rating_Coord = nan(size(rating_coord));
+        
+        % Iterate over each row
+        for j = 1:length(rating_coord)
+            % Get the screen height and width for the current trial
+            xysize = strsplit(string(subjectData.ScreenSize(j)), "x"); % splits the screensize into height and width
+            width = str2double(xysize(1));
+            height = str2double(xysize(2));
+            
+            if subjectData.nl_orientation(j) == 1 % if vertical
+                % Invert the Y coordinate and normalize by height
+                adjusted_rating_Coord(j) = (height - rating_coord(j)) / height;
+            elseif subjectData.nl_orientation(j) == 0 % if horizontal
+                % Normalize the X coordinate by width
+                adjusted_rating_Coord(j) = rating_coord(j) / width;
+            end
+        end
+        
+        % Assign the adjusted ratings back to the subjectData structure
+       subjectData.adj_coord = adjusted_rating_Coord;
+       subjectData.Rating = adjusted_rating_Coord;
+       subjectData.Rating(nan_idx | (0.2 > adjusted_rating_Coord > 0.8)) = NaN;
+       subjectData.zRating = nanzscore(subjectData.Rating);
+       kk(i, group) = nanmean(subjectData.Rating(1:10));
+       subjectData.kRating = subjectData.Rating - kk(i,group);
+
+
+       
+       
+       %subjectData.zRating = nanzscore(rating_coord);
+
+       [var, subjectTable, ratingschange_chosens] = PDGraphingTR_K1(subjectData, group);
+       % Includes calculation of previous previous time seen + difference in ratings 1 trial back
+       
+       %[var, subjectTable, ratingschange_chosens] = PDGraphingTR_K(subjectData, group); % alternatively 
+       
+       % PD Graphing - calculates model-based and model-free behaviour for
+       % a) choices 
+       % b) ratings
+       % c) makes a trialwise table (subjectTable) that has stick probability trial 2:end, based on 
+       % consistency, reward, correct, trial + subject ID
+       % Has two versions: PDGraphing_K is the longform, PDGraphing_K1 is shortform (maybe more accurate)
+   
+        % Add the Graphing variables to subjectData
+        subjectData.pMB = var.pMB;
+        subjectData.pMF = var.pMF;
+        %subjectData.pMTbA = var.pMTbA; % model based value transfer (based on last choice of current rated shape win/common)
+        %subjectData.pMFbA = var.pMFbA; % model free value transfer (based on last choice of current rated shape win/common)
+        %subjectData.ratingschange_chosens = ratingschange_chosens;
+
+        GroupTable = [GroupTable; subjectTable];
+        
+        %clear subjectTable
+        GroupData = [GroupData;subjectData];
+        subjectRatings = subjectData.Rating;
+        
+        % Variables needed potentially for making graphs
+        nl_ratings = table(subjectRatings, subjectData.nl_orientation);
+        allratings = [allratings; nl_ratings]; % collect ratings together with nl orientation for zscoring
+        %allbarv(i,:)=var.barv; % barv is the winc/common split of choices
+        %allbaraa(i,:)= var.baraa; %win/common split of shape ratings, chosen not re-seen
+        %allpMB(i,:)=var.pMB; % accumulare pMB from all subjects
+        %allpMF(i,:)= var.pMF; % accumulate   pMF from all subjects
+    
+        vars = struct2table(var, 'AsArray', 1);
+        grp = {getGroupLabel(group)};
+        
+        % performance measures
+        pcorrect = nanmean(subjectData.correct);
+        pstay = nanmean(subjectTable.stick); % probability of staying
+
+        s = table(i, grp, pcorrect, pstay); % gathering data for a short table
+        ss = [s, vars, dd];
+        shortTable = [shortTable; ss];
+        
+        
+    
+    end % Exits the subject-specific loop
+    
+    GroupTable.normratings(GroupTable.nl == 1) = nanzscore(allratings.subjectRatings(allratings.Var2 == 1));
+    GroupTable.normratings(GroupTable.nl == 0) = nanzscore(allratings.subjectRatings(allratings.Var2 == 0));
+   
+    % Gather all group data into stayprobTable
+    stayprobTable = [stayprobTable; GroupTable];
+    clear GroupTable
+    
+    %[output, ratingsTable] = AnalyseBehaviour_nl(GroupData, group, 0); % generates Daw plots for nl = 1 | nls ombined | nl = 0 ratings
+    [output, ratingsTable] = AnalyseBehaviour_K1(GroupData, group, 0); % Generate plots (data, group, plot graphs(1/0))
+    
+    % Save each group's data into a separate file
+    if options.savetables == 1
+        saveFileName = sprintf("groupData_group%d.mat", group); 
+        save(saveFileName, "GroupData");
+    end
+    
+    allratings_g{group} = allratings;    % used for the smoothed plot
+
+    data = GroupData;
+
+    if options.optimize == 1
+        fit(group) = fitWrapper(GroupData, 'LLmodelRating_K', 1, 1); %data, fucntion, EM, parallel
+    else
+        load('fit_new.mat')
+        fit = fit(group); 
+    end
+    
+    % Generate surrogate data
+    if options.GenerateSurrData == 1
+        SurrogateData = generateSurrData_K(data,fit.results.paramfit,'LLmodelRating_K'); 
+        FileName = sprintf("SurrData_Group%d", group);
+        save(FileName, "SurrogateData");
+    else 
+        load(sprintf('SurrData_Group%d.mat', group));   
+    end
+    
+    for subject = 1:length(GroupData)
+        y = [fit.results.paramfit(subject, :)];
+        [LL, RPEs] = LLmodelRating_extraction1(y, data, subject); % generate RPEs based on group data
+
+        % Make a table from the RPE data to append to stayprobTable
+        subjectRPEt = struct2table(RPEs); % expand the structure into a table
+        params = [params; y];
+        groupRPEt = [groupRPEt; subjectRPEt]; % aggregate the RPE data within the group
+        clear subjectRPEt % to prevent overwriting
+    end
+    
+    allRPEt = [allRPEt; groupRPEt]; % aggregate all the RPEs into all one table 
+    clear groupRPEt
+    
+    if options.fitRegression == 1   % fits a linear regression of RPEs vs ratingschange                                                                                                                                                                             
+        regressions{group} = fitRegression_April(SurrogateData, data, group);
+    end
+end % Exits the group loops
+
+stayprobTable = [stayprobTable, allRPEt]; % append the RPE table to stayprobTable
+
+%% Section from LMM_table script
+% stayprobTable.selected = nanzscore(stayprobTable.selected);
+% stayprobTable.con_lastseen = nanzscore(stayprobTable.con_lastseen);
+% stayprobTable.win_lastseen = nanzscore(stayprobTable.win_lastseen);
+stayprobTable.tp = categorical(stayprobTable.tp);
+
+TWcontrols = stayprobTable((stayprobTable.disease == 0),:);
+TWpdon = stayprobTable((stayprobTable.medication == 1),:);
+TWpdoff = stayprobTable((stayprobTable.medication == 0 & stayprobTable.disease == 1),:);
+TWpd = stayprobTable((stayprobTable.disease == 1),:);
+
+stats = struct();
+
+% lmes that I want to test
+model_specs = {
+    % pure reward increases stay behaviour 
+    'PDoffBehavLEWin', 'TWpdoff', 'stick ~ win*le + (1|subjectID)';
+    'PDonBehavLEWin', 'TWpdon', 'stick ~ win*le + (1|subjectID)';
+    'ControlBehavWin', 'TWcontrols', 'stick ~ win + (1|subjectID)';
+    
+    % model-based lmes
+    'PDBehav', 'TWpd', 'stick ~ win*con*medication + (1|subjectID)';
+    'ControlBehav', 'TWcontrols', 'stick ~ win*con + (1|subjectID)';
+    'PDonBehav', 'TWpdon', 'stick ~ win*con + (1|subjectID)';
+    'PDoffBehav', 'TWpdoff', 'stick ~ win*con + (1|subjectID)';
+    'AllBehav', 'stayprobTable', 'stick ~ win*con*group + (1|subjectID)';
+
+    % effects of clinical variables on stay behaviour/choice behaviour
+    'PDBehav_pdseverity', 'TWpd', 'stick ~ win*con*medication*pd_severity + (1|subjectID)';
+    'Behav_ami', 'stayprobTable', 'stick ~ win*con*group*motivation + (1|subjectID)';
+    'Behav_hads', 'stayprobTable', 'stick ~ win*con*group*depression + (1|subjectID)';
+    'Behav_grit', 'stayprobTable', 'stick ~ win*con*group*grit + (1|subjectID)';
+    'Behav_impulsivity', 'stayprobTable', 'stick ~ win*con*group*impulsivity + (1|subjectID)';
+
+    % all group model of rating strategy
+    'PO1_ALL', 'stayprobTable', 'normratings ~ win_lastseen*con_lastseen*selected*group + (1|subjectID)';
+    'PO1_ALL', 'stayprobTable', 'normratings ~ win_lastseen*con_lastseen*selected*group*nl + (1|subjectID)';
+
+    % single group models of rating strategy (simplest)
+    'PO1_HC', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected + (1|subjectID)';
+    'PO1_PDon', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected + (1|subjectID)';
+    'PO1_PDoff', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected + (1|subjectID)';
+
+    % single group models of rating strategy accounting for number line effects
+    'PO1_HC_nl', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected*nl + (1|subjectID)';
+    'PO1_PDon_nl', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*nl + (1|subjectID)';
+    'PO1_PDoff_nl', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*nl + (1|subjectID)';
+
+    % single group models of rating strategy accounting for reaction time
+    'PO1_HC_rttp', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected*RTTP + (1|subjectID)';
+    'PO1_PDon_rttp', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*RTTP + (1|subjectID)';
+    'PO1_PDoff_rttp', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*RTTP + (1|subjectID)';
+
+    % effect of clinical variables on the single group rating models
+    'PO1_HC_ami', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected*motivation + (1|subjectID)';
+    'PO1_PDon_ami', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*motivation + (1|subjectID)';
+    'PO1_PDoff_ami', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*motivation + (1|subjectID)';
+
+    'PO1_HC_hads', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected*depression + (1|subjectID)';
+    'PO1_PDon_hads', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*depression + (1|subjectID)';
+    'PO1_PDoff_hads', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*depression + (1|subjectID)';
+   
+    'PO1_HC_grit', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected*grit + (1|subjectID)';
+    'PO1_PDon_grit', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*grit + (1|subjectID)';
+    'PO1_PDoff_grit', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*grit + (1|subjectID)';
+
+    'PO1_HC_impulsivity', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected*impulsivity + (1|subjectID)';
+    'PO1_PDon_impulsivity', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*impulsivity + (1|subjectID)';
+    'PO1_PDoff_impulsivity', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*impulsivity + (1|subjectID)';
+    
+    'PO1_PDon_pdseverity', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected*pd_severity + (1|subjectID)';
+    'PO1_PDoff_pdseverity', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected*pd_severity + (1|subjectID)';
+
+    'PO1_PDoff_pdseverity', 'TWpd', 'normratings ~ win_lastseen*con_lastseen*selected*pd_severity*medication + (1|subjectID)';
+    
+    % added effect of trial to single group rating models
+    'PO1_HC_T', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (1|subjectID)';
+    'PO1_PDon_T', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (1|subjectID)';
+    'PO1_PDoff_T', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (1|subjectID)';
+
+    % added random slope of the rated shape (should it also be a fixed effect?)
+    'PO1_HC_T_tpRS', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (tp|subjectID)';
+    'PO1_PDon_T_tpRS', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (tp|subjectID)';
+    'PO1_PDoff_T_tpRS', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (tp|subjectID)';
+    
+    % random effect of rated shape
+    'PO1_HC_T_tpRE', 'TWcontrols', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (1|tp) + (1|subjectID)';
+    'PO1_PDon_T_tpRE', 'TWpdon', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (1|tp) + (1|subjectID)';
+    'PO1_PDoff_T_tpRE', 'TWpdoff', 'normratings ~ win_lastseen*con_lastseen*selected + trial + (1|tp) + (1|subjectID)';
+    
+    % temporal discounting factor of last seen distance 
+    'PO1_HC_T_td', 'TWcontrols', 'normratings ~ selected*win_lastseen*con_lastseen*lastseendis + trial + (1|subjectID)';
+    'PO1_PDon_T_td', 'TWpdon', 'normratings ~ selected*win_lastseen*con_lastseen*tp*lastseendis + trial + (1|subjectID)';
+    'PO1_PDoff_T_td', 'TWpdoff', 'normratings ~ selected*win_lastseen*con_lastseen*tp*lastseendis + trial + (1|subjectID)';
+
+     % single group models of rating strategy accounting for reaction time
+    'HC_simplewin', 'TWcontrols', 'normratings ~ win*con + trial + (1|subjectID)';
+    'PDon_simplewin', 'TWpdon', 'normratings ~ win*con + trial + (1|subjectID)';
+    'PDoff_simplewin', 'TWpdoff', 'normratings ~ win*con + trial + (1|subjectID)';
+};
+
+% Loop through each model specification
+for i = 1:size(model_specs, 1)
+    model_name = model_specs{i, 1}; % get the model name from the specified model
+    data_var = model_specs{i, 2}; % get the data table specified (Pd on/off, controls, all...)
+    formula = model_specs{i, 3}; % get the model formula
+    
+   try
+        % Fit the model
+        d=eval(data_var);
+        model = fitlme( d, formula);       
+        
+        % Extract statistics using a self-made function
+        stats = extract_stats(model, i, stats, model_name, data_var);
+        stats.fm = formula(i);
+   catch ME % to catch is i've made a mistake in the formula
+        fprintf('Error with model: %s\n', model_name);
+        fprintf('Error message: %s\n', ME.message);
+    end
+end
+
+LMMT = struct2table(stats); % convert the model stats to a table
+hs = size(LMMT);
+
+% Initialize empty tables for significant effects
+significantFEs = table();
+significantFEs_stick = table();
+significantFEs_normratings = table();
+
+for i = 1:hs(1)
+    FEs = LMMT.FEs{i,:};
+    data = LMMT.Data(i);
+    formula = model_specs(i,3);
+    for j = 1:length(FEs)
+        if FEs(j).pValue < 0.05
+            f = struct2table(FEs(j,:));
+            f.Name = string(f.Name);
+            f.data = string(data);
+            f.AIC = LMMT.AIC(i);
+            f.BIC = LMMT.BIC(i);
+            f.LL = LMMT.LogLikelihood(i);
+            f.formula = string(formula);
+            
+            significantFEs = [significantFEs; f];
+
+            % Check if the model explains 'stick' or 'normratings' or 'RPEs'
+            if contains(formula, 'stick')
+                significantFEs_stick = [significantFEs_stick; f];
+            elseif contains(formula, 'normratings')
+                significantFEs_normratings = [significantFEs_normratings; f];
+            elseif contains(formula, 'RPE')
+                signifianceFEs_RPEs = [significantFEs_RPEs; f]; % significant RPE effects
+            end
+        else
+            continue; % If any pValue in FEs is less than 0.05, add the row and break
+        end
+    end
+end
+
+% Convert arrays to tables if not empty
+if ~isempty(significantFEs_stick)
+    writetable(significantFEs_stick, 'significantFEs_stick.xlsx');
+end
+
+if ~isempty(significantFEs_normratings)
+    writetable(significantFEs_normratings, 'significantFEs_normratings_new.xlsx');
+end
+
+% Write the combined table to an Excel file
+if options.savetables == 1
+    writetable(significantFEs, 'significantFEs.xlsx');
+end
+
+
+
+%% Pipeline for establishing the best fitting RPE
+models = struct();
+rpeNames = {'RPE1', 'RPE2', 'RPE3', 'RPE4', 'RPE5', 'RPE6', 'RPE7', 'RPE8', 'RPE9', 'RPE10', 'RPE11'}; % Your list of RPEs
+% accumulate the linear models in models structure
+for i = 1:length(rpeNames)
+    formula = ['ratingschange_chosens ~ ' rpeNames{i} ' + (1|subjectID)']; % Construct a formula string
+    models.(rpeNames{i}) = fitlme(stayprobTable, formula);
+end
+
+aicValues = zeros(length(rpeNames), 1);
+bicValues = zeros(length(rpeNames), 1);
+
+for i = 1:length(rpeNames)
+    aicValues(i) = models.(rpeNames{i}).ModelCriterion.AIC;
+    bicValues(i) = models.(rpeNames{i}).ModelCriterion.BIC;
+    LL(i) = models.(rpeNames{i}).LogLikelihood;
+end
+
+% Find the model with the minimum AIC and BIC
+[minAIC, idxAIC] = min(aicValues);
+[minBIC, idxBIC] = min(bicValues);
+[minLL, idxLL] = min(LL);
+
+bestModelAIC = rpeNames{idxAIC};
+bestModelBIC = rpeNames{idxBIC};
+bestModelLL = rpeNames{idxLL};
+
+%% determine the best fitting RPE for every group indidvidually
+for i = 1:length(rpeNames)
+    formula = ['ratingschange_chosens ~ ' rpeNames{i} ' + (1|subjectID)']; % Construct a formula string
+    %models.(rpeNames{i}) = 
+    fitlme(TWcontrols, formula)
+    % to study a different group, just change the sub-table used:
+    % TWcontrols, TWpdon, TWpdoff
+end
+
+% determine the best fit
+aicValues = zeros(length(rpeNames), 1);
+bicValues = zeros(length(rpeNames), 1);
+for i = 1:length(rpeNames)
+    aicValues(i) = models.(rpeNames{i}).ModelCriterion.AIC;
+    bicValues(i) = models.(rpeNames{i}).ModelCriterion.BIC;
+    LL(i) = models.(rpeNames{i}).LogLikelihood;
+end
+
+% Find the model with the minimum AIC and BIC
+[minAIC, idxAIC] = min(aicValues);
+[minBIC, idxBIC] = min(bicValues);
+[minLL, idxLL] = min(LL);
+
+bestModelAIC = rpeNames{idxAIC};
+bestModelBIC = rpeNames{idxBIC};
+bestModelLL = rpeNames{idxLL};

--- a/PDGraphingTR_K1.m
+++ b/PDGraphingTR_K1.m
@@ -1,0 +1,232 @@
+function  [var, RatingsTable, ratingschange_chosens] = PDGraphingTR_K1(result, group) 
+ % Adapted to work for the MD young healthy controls when loaded in as pure data files
+
+%% PDGraphingTR 
+c1=[result.A(:,1)];
+win=[result.R]; % reward (1) or non-reward (0)
+con=[result.trans]; % same as conmap, but transposed    
+start = [result.start]; % start s1
+finish = [result.finish]; % end s1
+tp = [result.ratingIdx]; % 1 to 5, which item probed, also referred to as ratedshape in some scripts
+irrels = [result.shapeIdx]; % which s1 shapes were presented (red | blue)
+conmap=[result.trans]; % common (1) or rare (0)
+correct =[result.correct]; % should the s2 choice have led to a reward?
+startTP = [result.startTransferChoice]; % start of rating
+endTP = [result.endTransferChoice]; % end of rating
+normratings = [result.zRating]; % normalised ratings
+SubjectID = result.ID;
+subjectID = repelem(SubjectID, length(c1), 1); % subjectID for subjectTable
+trial = (1:length(c1))';
+ratings = [result.Rating]; % normratings
+
+RT = finish - start; idx = true(length(c1),1); % calculate s1 choice time and remove times over 4s
+if RT>4000
+    idx = false;
+end
+RTTP = (endTP - startTP); % time taken for rating
+
+% Variables for the table
+medication = repelem(result.Med, length(c1), 1);
+disease = repelem(result.Dis, length(c1), 1);
+age = repelem(result.Age, length(c1), 1);
+pd_severity = repelem(result.UPDRST, length(c1), 1);
+motivation = repelem(result.AMI, length(c1), 1);
+depression = repelem(result.HADS, length(c1), 1);
+grit = repelem(result.Grit, length(c1), 1);
+impulsivity = repelem(result.Impulsivity, length(c1), 1);
+le = repelem(result.LearningEffect, length(c1), 1);
+nl = result.nl_orientation;
+Screen = result.ScreenSize;
+grp = repelem(cellstr(getGroupLabel(group)),192,1);
+version = categorical(result.version);
+rating_coord = result.adj_coord;
+
+% PDGraphingTR continued
+stick=[nan; c1(1:end-1)==c1(2:end)]; % did they repeat ths s1 choice?
+stickwin = stick == 1 & win == 1;% trials where i stuck and won as 1;
+s=stick(2:end);
+stick(idx == 1) = [s; NaN]; % set stick behaviour 2:end as (1:end-1 + NaN)
+var.stick = stick;
+win(win == 0) = -1;
+win(isnan(win))=false;
+con(con == 0) = -1;
+con(isnan(con))=false;
+
+select_mbmf = [
+    (win(1:end-1) == 1) & (con(1:end-1) == 1), ...
+    (win(1:end-1) == 1) & (con(1:end-1) == -1), ...
+    (win(1:end-1) == -1) & (con(1:end-1) == 1), ...
+    (win(1:end-1) == -1) & (con(1:end-1) == -1)
+]; % clasifies trials 
+
+% stay probability
+barv(1)=nanmean(stick(select_mbmf(:,1)));% bar(1) is rewarded and common; 
+barv(2)=nanmean(stick(select_mbmf(:,2)));% bar(2) is rewarded and rare
+barv(3)=nanmean(stick(select_mbmf(:,3)));% bar(3) is not-rewarded and common;
+barv(4)=nanmean(stick(select_mbmf(:,4)));% bar(4) is not-rewarded and rare;
+var.barv = barv;
+
+%% Plotting Daw graphs for each participant (now as a subplot)
+    % Behavioral (Daw) subplots
+    % subplot(3, 10, SubjectID); % Create a subplot in a 3x6 grid
+    % barColors = [1 0 0; 1 0 0; 0 0 1; 0 0 1];
+    % bar(barv); 
+    % % Customize plot labels and title if needed
+    % ylabel('Stay Behaviour');
+    % title(['Subject ', num2str(SubjectID)]);
+    % sgtitle('Stay behaviour Daw graphs for Controls ')
+    % % Replace numerical labels with x-labels
+    % colormap(barColors);
+    % conditions = {'R/C', 'R/R', 'NR/C', 'NR/R'};
+    % xticks(1:4);
+    % xticklabels(conditions);
+    % ylim([0.4 1.0]);
+
+%measures of MB and MFness of BEHAVIOUR
+var.pMB = ((barv(1)+barv(4))-(barv(3)+barv(2)));%mb measure win common + lose uncommon - win rare + lose common
+var.pMBPOS = (barv(1))-(barv(2)); % probability of sticking with a common vs a rare winning s1 choice
+var.pMBNEG = (barv(4))-(barv(3)); % probability of sticking with a common vs rare losing s1 choice
+var.pMF = ((barv(1)+barv(2))-(barv(3)+barv(4))); %mf index, total stick after win - total stick after lose
+var.mbi = var.pMB - var.pMF; % mb - mf
+var.pwin = (sum(win == 1))/length(c1); % probability of winning = mean times participant won
+
+antic1=abs(c1-3); % 1 to 2 and 2 to 1 = opposite of c1
+
+
+% initialize variables for Ratings loop
+chosens = nan(length(c1), 1);
+unchosens = nan(length(c1), 1);
+ratingschange_chosens = nan(length(c1), 1);
+lastseentrial2 = nan(length(c1), 1);
+lastseentrial = nan(length(c1), 1);
+win_lastseen = nan(length(c1), 1);
+con_lastseen = nan(length(c1), 1);
+selected = nan(length(c1), 1);
+win_lastseen2 = nan(length(c1), 1);
+con_lastseen2 = nan(length(c1), 1);
+selected2 = nan(length(c1), 1);
+trialdiff = nan(length(c1), 1);
+rtc = nan(length(c1), 1);
+nrtRating = nan(length(c1), 1);
+
+%% Ratingschange function
+for i = 1:length(c1) % for each trial
+    if c1(i) == 0 || isnan(c1(i)) % if there is no c1, make (un)chosen shapes nan
+        chosens(i) = nan;
+        unchosens(i) = nan;
+    else
+        chosens(i) = irrels( i, c1(i) );   %find the shape for the chosen colour
+        unchosens(i) = irrels(i,antic1(i)); % find the shape for the unchosen colour
+    end
+
+    lst = find(chosens(1:i) == tp(i) | unchosens(1:i) == tp(i), 1, 'last');
+    
+    % needs to be fine tuned
+    if ~isempty(lst)
+        lastseentrial(i) = lst;
+        
+        if chosens(lastseentrial(i)) == tp(i)
+            selected(i) = 1;
+            
+        elseif unchosens(lastseentrial(i)) == tp(i)
+            selected(i) = -1;
+        else
+            selected(i) = 0; % This case should not happen if the find condition was true
+        end
+        
+        win_lastseen(i) = win(lastseentrial(i)); 
+        % last time it was seen, did it lead to a win? (regardless of it if was chosen or not)
+        con_lastseen(i) = con(lastseentrial(i));
+        % last time it was seen, did it lead to a consistent trial? (regardless of it if was chosen or not)
+    end
+    
+    lst2 = find(chosens(1:i) == tp(i) | unchosens(1:i) == tp(i), 2, 'last');
+    % looks at the trial seen before the last trial seen
+    if ~isempty(lst2)
+        lastseentrial2(i) = lst2(1);
+
+        if chosens(lastseentrial2(i)) == tp(i)
+            selected2(i) = 1;
+            
+        elseif unchosens(lastseentrial2(i)) == tp(i)
+            selected2(i) = -1;
+        else
+            selected2(i) = 0; % This case should not happen if the find condition was true
+        end
+        
+        win_lastseen2(i) = win(lastseentrial2(i)); 
+        % last time it was seen, did it lead to a win? (regardless of it if was chosen or not)
+        con_lastseen2(i) = con(lastseentrial2(i));
+        % last time it was seen, did it lead to a consistent trial? (regardless of it if was chosen or not)
+    end
+
+    % For the current rated shape, what was the difference between the last rating assigned and the current rating
+    lrt = find(tp(1:i-1) == tp(i), 1, 'last');
+    if ~isempty(lrt)
+        trialdiff(i) = normratings(i) - normratings(lrt);
+    end
+end
+
+for i = 1:length(c1)
+        % does halo effect persist for the next time the rated shape on a win trial is rated?
+    nrt_halo = find(tp(i) == tp(i+1:end), 1, 'first');
+
+    if ~isempty(nrt_halo) 
+        if isempty(find(chosens(i) == chosens(nrt_halo), 1))
+            nrtRating(i) = normratings(nrt_halo);% What was rating on the next 'halo' effect rated shape?
+            rtc(i) = nrtRating(i)  - normratings(i); % what was the difference between the 1st and next?
+        end
+    end
+end
+
+RatingsTable = table();
+RatingsTable = table(subjectID, grp, Screen, trial, le, version, age, medication, disease, nl, pd_severity, motivation, depression, grit, ...
+    impulsivity, stick, win, con, chosens,  unchosens, tp, trialdiff, normratings, nrtRating, rtc, rating_coord, RT, RTTP, lastseentrial, selected, win_lastseen, con_lastseen,...
+    lastseentrial2, selected2, win_lastseen2, con_lastseen2);
+
+ws(1) = nanmean(normratings((win_lastseen==1) & (selected==1)));
+ws(2) = nanmean(normratings((win_lastseen==-1) & (selected==1)));
+ws(3) = nanmean(normratings((win_lastseen==1) & (selected==-1)));
+ws(4) = nanmean(normratings((win_lastseen==-1) & (selected==-1)));
+
+% Calculate standard errors for the means
+se(1) = nanstd(normratings((win_lastseen==1) & (selected==1))) / sqrt(sum((win_lastseen==1) & (selected==1)));
+se(2) = nanstd(normratings((win_lastseen==-1) & (selected==1))) / sqrt(sum((win_lastseen==-1) & (selected==1)));
+se(3) = nanstd(normratings((win_lastseen==1) & (selected==-1))) / sqrt(sum((win_lastseen==1) & (selected==-1)));
+se(4) = nanstd(normratings((win_lastseen==-1) & (selected==-1))) / sqrt(sum((win_lastseen==-1) & (selected==-1)));
+
+sgtitle('Ratings based on last seen & NOT selected', 'Fontsize', 24)
+subplot(4, 5, SubjectID); % Create a subplot in a 3x6 grid
+barColors = [1 0 0; 0 0 1];
+% Create the bar plot
+b = bar(ws(3:4)); 
+hold on;
+x = 1:length(ws(3:4)); % X locations of the bars
+errorbar(x, ws(3:4), se(3:4), 'k', 'linestyle', 'none', 'LineWidth', 2); 
+
+if SubjectID == 1 || SubjectID ==6 || SubjectID ==11 || SubjectID == 16
+    ylabel('Zscored ratings');
+end
+
+% Replace numerical labels 
+title(['sub ' num2str(SubjectID)], 'Fontsize', 12)
+colormap(barColors);
+conditions = {'Win', 'Non-Win'};
+xticks(1:2);
+xticklabels(conditions);
+set(findall(gcf, '-property', 'FontSize'), 'FontSize', 24);
+ylim([-0.7 0.7])
+
+% subplot(1, 2, 2); % Create a subplot in a 3x6 grid
+% barColors = [0 0 1; 1 0 0];
+% bar(ws(3:4)); 
+% % Customize plot labels and title if needed
+% ylabel('Zscored ratings');
+% title('Last Seen Not Selected');
+% % Replace numerical labels with x-labels
+% colormap(barColors);
+% conditions = {'Win', 'Non Win'};
+% xticks(1:2);
+% xticklabels(conditions);
+
+end


### PR DESCRIPTION
These scripts incorporate the 
1) Full script, that extracts the data, pulls in either PDGraphing_K or PDGraphing_K1 to analyse stay and rating behavior, then AnalyseBehaviour_1 or _nl to make daw plots, generates a stayprob table and runs all the possible mixed effect models, saves these tables. Optimises parameters, generates surrogate data, and tries to establish the best-fitting RPE
2) PDGraphing_K which has all the temporal discounting measures as initially sent by Max, includes diffratings, woncs, consiscs etc calculations
3) PDGraphing_K1 calculates last seen based on a different method + calculation of 'carry over' of the halo effect to the next rating of the shape that has been highly rated after a reward
4) Analysebehaviour_nl and Analysebehaviour_1: just makes the daw plots used + _1 also adds a pMF and pMB bar chart for quantification/visualization of indices.
5) Final figures: used in the manuscript to keep track